### PR TITLE
Fix (data_prep): partial dates data

### DIFF
--- a/R/data_prep.R
+++ b/R/data_prep.R
@@ -104,7 +104,7 @@ data_prep<-function (df, trends = T, subind = FALSE, anomaly=NULL)
   ### end helper function
 
 
-  if (!all(grepl("^[0-9]{4}$", df_dat[, 1]) | is.na(df_dat[, 1]))) {
+  if (!all(grepl("^[0-9]{4}(\\.[0-9]+)?$", df_dat[, 1]) | is.na(df_dat[, 1]))) {
     df_dat[, 1] <- clean_dates_to_partial_year(df_dat[, 1])
   }
 

--- a/testing/Feature_DataType_Testing.qmd
+++ b/testing/Feature_DataType_Testing.qmd
@@ -10,7 +10,7 @@ Purpose: Place where code is setup to test new functions on all of our example d
 
 #Install branch IEAnalyzer
 ## Replace ref with test branch name
-devtools::install_github("Gulf-IEA/IEAnalyzeR", ref = "fix-partial_dates_data")
+devtools::install_github("Gulf-IEA/IEAnalyzeR", ref = "fix-partial_dates_data", force = T)
 
 library(IEAnalyzeR)
 ```

--- a/testing/Feature_DataType_Testing.qmd
+++ b/testing/Feature_DataType_Testing.qmd
@@ -1,0 +1,93 @@
+---
+title: "Feature_DataType_Testing"
+format: html
+---
+
+Purpose: Place where code is setup to test new functions on all of our example data.
+
+
+```{r libraries}
+
+#Install branch IEAnalyzer
+## Replace ref with test branch name
+devtools::install_github("Gulf-IEA/IEAnalyzeR", ref = "fix-partial_dates_data")
+
+library(IEAnalyzeR)
+```
+
+```{r load practice data}
+
+#Annual x 1 fish
+single_metric
+
+#Monthly (Year-Month ex:2000-01) x 2 units x 2 categories
+multi_unit_monthly
+
+#Annual data x 4 locations
+annual_by_area
+
+#Annual x 2 categories x 2 locations
+two_cat
+
+```
+
+# Test convert_cleaned_data
+```{r}
+#Single metric add headers
+indicator_names <- c("Red fish biomass")
+unit_names <- c("Thousand pounds")
+extent_names <- c("")
+
+  # call the function
+single_table <- convert_cleaned_data(single_metric, indicator_names, unit_names, extent_names)
+
+#Monthly (multi) metric add headers
+indicator_names <- rep("Environmental parameters", ncol(multi_unit_monthly)-1)
+unit_names <- c("Temperature (°F)", "Salinity (ppm)", "Temperature (°F)", "Salinity (ppm)")
+extent_names <- c("Area A", "Area B", "Area A", "Area B")
+
+  # call the function
+monthly_table <- convert_cleaned_data(multi_unit_monthly, indicator_names, unit_names, extent_names)
+
+#Multi metric add headers
+indicator_names <- rep("Population", ncol(annual_by_area)-1)
+unit_names <- rep("Millions", ncol(annual_by_area)-1)
+extent_names <- c("Narnia", "Westeros", "Wakanda", "Arrakis")
+
+  # all the function
+multi_table <- convert_cleaned_data(annual_by_area, indicator_names, unit_names, extent_names)
+
+#Two category data add headers
+indicator_names <- rep("Count and Revenue", ncol(two_cat)-1)
+unit_names <- c("Revenue (USD)", "Count", "Revenue (USD)", "Count")
+extent_names <- c("Narnia", "Narnia", "Wakanda", "Wakanda")
+
+# all the function
+twocat_table <- convert_cleaned_data(two_cat, indicator_names, unit_names, extent_names)
+
+```
+
+
+# Test Data Prep
+```{r}
+sing_met_form<- data_prep(single_table)
+
+mult_mon_form<- data_prep(monthly_table)
+
+ann_area_form<- data_prep(multi_table)
+
+two_cat_form<- data_prep(twocat_table)
+```
+
+
+# Test Data Plot
+```{r}
+plot_fn_obj(sing_met_form)
+
+plot_fn_obj(ann_area_form)
+
+plot_fn_obj(mult_mon_form)
+
+plot_fn_obj(two_cat_form)
+```
+


### PR DESCRIPTION
I had data that was already in the "partial year" format (e.g. 1993.0396). The if statement for using the `clean_dates_to_partial_year` function searched for if the year category was not 4 numeric characters, `"^[0-9]{4}$"` (normal year). I changed that to include "."
 and a numeric characters after the "." `"^[0-9]{4}(\\.[0-9]+)?$"`. It now works. 

I also added "Feature_DataType_Testing" in the testing folder that loads and formats our test/example data and runs the main data_prep and plotting function so that when we make changes we can test on all the datatypes. 